### PR TITLE
Easy Installation and SSL-Management-Stuff

### DIFF
--- a/files/etc/nginx/sites-available/owncloud
+++ b/files/etc/nginx/sites-available/owncloud
@@ -9,8 +9,8 @@ server {
 
         ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
         ssl_ciphers         AES128-SHA:AES256-SHA:RC4-SHA:DES-CBC3-SHA:RC4-MD5;
-        ssl_certificate     /etc/nginx/cert.crt;
-        ssl_certificate_key /etc/nginx/cert.key;
+        ssl_certificate     /etc/nginx/SSL/cert.crt;
+        ssl_certificate_key /etc/nginx/SSL/cert.key;
         ssl_session_cache   shared:SSL:10m;
         ssl_session_timeout 10m;
 

--- a/files/usr/bin/owncloud-bootstrap
+++ b/files/usr/bin/owncloud-bootstrap
@@ -1,5 +1,20 @@
 #!/bin/sh
-#test
+
+# Create SSL-Certificates on First Boot
+
+if ! [ -f /etc/nginx/SSL/cert.key ]
+  then 
+     rm -r /etc/nginx/SSL
+     cd /etc/nginx/
+     mkdir SSL
+     cd SSL
+     openssl genrsa -des3 -out cert.key 1024
+     openssl req -new -key cert.key -out cert.csr
+     cp cert.key cert.key.org
+     openssl rsa -in cert.key.org -out cert.key
+     openssl x509 -req -days 365 -in cert.csr -signkey cert.key -out cert.crt
+fi
+
 # Create log files (to prevent errors)
 touch /var/log/nginx/access.log
 touch /var/log/nginx/error.log

--- a/files/usr/bin/owncloud-bootstrap
+++ b/files/usr/bin/owncloud-bootstrap
@@ -1,5 +1,5 @@
 #!/bin/sh
-
+#test
 # Create log files (to prevent errors)
 touch /var/log/nginx/access.log
 touch /var/log/nginx/error.log

--- a/run.sh
+++ b/run.sh
@@ -1,1 +1,1 @@
-docker run -i -t --name owncloud -p 80:80 -p 443:443 -v /data/owncloud-storage:/var/www/html/owncloud/data -v /data/owncloud:/var/www/html/owncloud/config owncloud
+docker run -i -t --name owncloud -p 443:443 -v /data/owncloud/SSL:/etc/nginx/SSL -v /data/owncloud-storage:/var/www/html/owncloud/data -v /data/owncloud:/var/www/html/owncloud/config --entrypoint  '/usr/bin/owncloud-bootstrap' owncloud


### PR DESCRIPTION
Just added some kind of Easy Installation Stuff: Thed docker container starts straight into the owncloud-bootstrap Script and creates SSL-Certificates, which are given back to the doker host.
